### PR TITLE
Fix missing android cfg attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["os"]
 [dependencies]
 num_cpus = "^1.6.2"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))'.dependencies]
 libc = "^0.2.30"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
This PR fixes missing `target_os = "android"` cfg attributes, which made the get/set operations on Android simply noops. 

With this PR, the crate behaves as expected on Android.