### PR TITLE
macos: Remove wrong semicolon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 #[cfg(target_os = "macos")]
 #[inline]
 fn set_for_current_helper(core_id: CoreId) -> bool {
-    macos::set_for_current(core_id);
+    macos::set_for_current(core_id)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
The new version broke macos support: https://github.com/hermitcore/uhyve/actions/runs/3511902404/jobs/5883081149.