### PR TITLE
Fix set_for_current_helper on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 #[cfg(target_os = "macos")]
 #[inline]
 fn set_for_current_helper(core_id: CoreId) -> bool {
-    macos::set_for_current(core_id);
+    macos::set_for_current(core_id)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
`core_affinity::set_for_current(CoreId)` is not working on macOS due to the semicolon in the function definition making it return `()` instead of `bool`, removing it should fix things up.