### PR TITLE
Don't link System framework on macos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,6 @@ mod macos {
 
     const THREAD_AFFINITY_POLICY: thread_policy_flavor_t = 4;
 
-    #[link(name = "System", kind = "framework")]
     extern {
         fn thread_policy_set(
             thread: thread_t,


### PR DESCRIPTION
As per [docs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html), `System.framework` shouldn't be used

I have verified that crabz runs fine on aarch64 macos after this patch