### PR TITLE
Actually set/get cpu affinity on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["os"]
 [dependencies]
 num_cpus = "^1.14.0"
 
-[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
 libc = "^0.2.30"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ for handle in handles.into_iter() {
 
 # Platforms
 
-`core_affinity_rs` should work on Linux, Windows, Mac OSX, and Android.
+`core_affinity_rs` should work on Linux, Windows, Mac OSX, FreeBSD, and Android.
 
 `core_affinity_rs` is continuously tested on:
   * `x86_64-unknown-linux-gnu` (Linux)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,7 @@ fn get_core_ids_helper() -> Option<Vec<CoreId>> {
 )))]
 #[inline]
 fn set_for_current_helper(_core_id: CoreId) -> bool {
-    true
+    false
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,12 @@
 //! }
 //! ```
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd"
+))]
 extern crate libc;
 
 #[cfg_attr(all(not(test), not(target_os = "macos")), allow(unused_extern_crates))]
@@ -405,18 +410,181 @@ mod macos {
     }
 }
 
+
+// FreeBSD Section
+
+#[cfg(target_os = "freebsd")]
+#[inline]
+fn get_core_ids_helper() -> Option<Vec<CoreId>> {
+    freebsd::get_core_ids()
+}
+
+#[cfg(target_os = "freebsd")]
+#[inline]
+fn set_for_current_helper(core_id: CoreId) -> bool {
+    freebsd::set_for_current(core_id)
+}
+
+#[cfg(target_os = "freebsd")]
+mod freebsd {
+    use std::mem;
+
+    use libc::{
+        cpuset_getaffinity, cpuset_setaffinity, cpuset_t, CPU_ISSET,
+        CPU_LEVEL_WHICH, CPU_SET, CPU_SETSIZE, CPU_WHICH_TID,
+    };
+
+    use super::CoreId;
+
+    pub fn get_core_ids() -> Option<Vec<CoreId>> {
+        if let Some(full_set) = get_affinity_mask() {
+            let mut core_ids: Vec<CoreId> = Vec::new();
+
+            for i in 0..CPU_SETSIZE as usize {
+                if unsafe { CPU_ISSET(i, &full_set) } {
+                    core_ids.push(CoreId { id: i });
+                }
+            }
+
+            Some(core_ids)
+        } else {
+            None
+        }
+    }
+
+    pub fn set_for_current(core_id: CoreId) -> bool {
+        // Turn `core_id` into a `libc::cpuset_t` with only
+        // one core active.
+        let mut set = new_cpu_set();
+
+        unsafe { CPU_SET(core_id.id, &mut set) };
+
+        // Set the current thread's core affinity.
+        let res = unsafe {
+            // FreeBSD's sched_setaffinity currently operates on process id,
+            // therefore using cpuset_setaffinity instead.
+            cpuset_setaffinity(
+                CPU_LEVEL_WHICH,
+                CPU_WHICH_TID,
+                -1, // -1 == current thread
+                mem::size_of::<cpuset_t>(),
+                &set,
+            )
+        };
+        res == 0
+    }
+
+    fn get_affinity_mask() -> Option<cpuset_t> {
+        let mut set = new_cpu_set();
+
+        // Try to get current core affinity mask.
+        let result = unsafe {
+            // FreeBSD's sched_getaffinity currently operates on process id,
+            // therefore using cpuset_getaffinity instead.
+            cpuset_getaffinity(
+                CPU_LEVEL_WHICH,
+                CPU_WHICH_TID,
+                -1, // -1 == current thread
+                mem::size_of::<cpuset_t>(),
+                &mut set,
+            )
+        };
+
+        if result == 0 {
+            Some(set)
+        } else {
+            None
+        }
+    }
+
+    fn new_cpu_set() -> cpuset_t {
+        unsafe { mem::zeroed::<cpuset_t>() }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use num_cpus;
+
+        use super::*;
+
+        #[test]
+        fn test_freebsd_get_affinity_mask() {
+            match get_affinity_mask() {
+                Some(_) => {}
+                None => {
+                    assert!(false);
+                }
+            }
+        }
+
+        #[test]
+        fn test_freebsd_get_core_ids() {
+            match get_core_ids() {
+                Some(set) => {
+                    assert_eq!(set.len(), num_cpus::get());
+                }
+                None => {
+                    assert!(false);
+                }
+            }
+        }
+
+        #[test]
+        fn test_freebsd_set_for_current() {
+            let ids = get_core_ids().unwrap();
+
+            assert!(ids.len() > 0);
+
+            let res = set_for_current(ids[0]);
+            assert_eq!(res, true);
+
+            // Ensure that the system pinned the current thread
+            // to the specified core.
+            let mut core_mask = new_cpu_set();
+            unsafe { CPU_SET(ids[0].id, &mut core_mask) };
+
+            let new_mask = get_affinity_mask().unwrap();
+
+            let mut is_equal = true;
+
+            for i in 0..CPU_SETSIZE as usize {
+                let is_set1 = unsafe { CPU_ISSET(i, &core_mask) };
+                let is_set2 = unsafe { CPU_ISSET(i, &new_mask) };
+
+                if is_set1 != is_set2 {
+                    is_equal = false;
+                }
+            }
+
+            assert!(is_equal);
+        }
+    }
+}
+
 // Stub Section
 
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "freebsd"
+)))]
 #[inline]
 fn get_core_ids_helper() -> Option<Vec<CoreId>> {
     None
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "freebsd"
+)))]
 #[inline]
-fn set_for_current_helper(core_id: CoreId) -> bool {
-    false
+fn set_for_current_helper(_core_id: CoreId) -> bool {
+    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This replaces the stubs with an actual implementation based on FreeBSD's cpuset_*affinity functions (FreeBSD's sched_*affinity functions currently operate on process id instead of thread id, so they couldn't be used).

I didn't test this beyond unit tests.