### PR TITLE
Add a PartialOrd,Ord,Hash on CoreId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ pub fn set_for_current(core_id: CoreId) -> bool {
 }
 
 /// This represents a CPU core.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CoreId {
     pub id: usize,
 }


### PR DESCRIPTION
It's useful to use `CoreId` as keys in HashMap and BTreeMap. Also added a `repr(transparent)` to give it the `usize` representation, useful for FFI.